### PR TITLE
Remove pathlib dependency

### DIFF
--- a/seclytics/seclytics.py
+++ b/seclytics/seclytics.py
@@ -1,7 +1,7 @@
 """Main seclytics endpoint."""
 from hashlib import sha1
 import sys
-from pathlib import Path
+import os
 import requests
 from .exceptions import InvalidAccessToken, OverQuota, ApiError
 from . import __version__
@@ -207,15 +207,15 @@ class BulkDownload(object):
         """
         self.api = api
         self.endpoint = endpoint
-        self.data_dir = Path('')
+        self.data_dir = ''
         if data_dir:
-            self.data_dir = Path(data_dir)
+            self.data_dir = data_dir
 
     @property
     def filename(self):
         """Determine the file name."""
-        filename = Path(self.endpoint).name
-        return self.data_dir.joinpath(filename)
+        filename = os.path.basename(self.endpoint)
+        return os.path.join(self.data_dir, filename)
 
     @property
     def api_reponse(self):
@@ -229,7 +229,7 @@ class BulkDownload(object):
     def download(self):
         """Download API response to file."""
         response = self.api_reponse
-        with self.filename.open('wb') as file_handle:
+        with open(self.filename, 'wb') as file_handle:
             for chunk in response.iter_content(chunk_size=1024):
                 if chunk:
                     file_handle.write(chunk)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ about = {}
 with open(path.join(here, 'seclytics', '__version__.py'), 'r') as f:
     exec(f.read(), about)
 
-requires = ['requests', 'texttable', 'ipaddress', 'pathlib']
+requires = ['requests', 'texttable', 'ipaddress']
 
 test_require = requires + ['pytest', 'requests-mock']
 

--- a/tests/test_bulk_download.py
+++ b/tests/test_bulk_download.py
@@ -41,7 +41,7 @@ class TestBulkDownload:
         
         file_path = api_client.bulk_api_download('test.json', '/tmp/')
         assert str(file_path) == '/tmp/test.json'
-        data = json.load(file_path.open('r'))
+        data = json.load(open(file_path, 'r'))
         assert data.get('name') == 'test.json'
         
     def test_download_private(self, test_requests):
@@ -49,7 +49,7 @@ class TestBulkDownload:
         api_client = Seclytics('')
         file_path = api_client.bulk_api_download('private/private_test.json', '/tmp/')
         assert str(file_path) == '/tmp/private_test.json'
-        data = json.load(file_path.open('r'))
+        data = json.load(open(file_path, 'r'))
         assert data.get('name') == 'private_test.json'
 
     def test_download_missing(self, test_requests):


### PR DESCRIPTION
Some python 2.7 deployments can't install pathlib so we need to remove
it.