### PR TITLE
Add flexibility of using just one of the bloom filters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2021-03-31
+### Added
+- Added ability to only check predicted or malicious ips
+- Added stdout to show downloading bloom filter name.
+### Changed
+- Remove BloomCategory initialization requirement of bloom filter path.
+
 ## [0.2.3] - 2020-09-01
 ### Added
 - Added ability to download private bulk items
 - Added tests and some pydoc
-
 
 ## [0.2.2] - 2020-05-26
 ### Added

--- a/seclytics/__version__.py
+++ b/seclytics/__version__.py
@@ -1,7 +1,7 @@
 __title__ = 'seclytics'
 __description__ = 'Seclytics Threat Intelligence API.'
 __url__ = 'https://www.seclytics.com/'
-__version__ = '0.2.3'
+__version__ = '0.2.4'
 __author__ = 'Jason pope'
 __author_email__ = 'jpope@seclytics.com'
 __license__ = 'Apache License 2.0'

--- a/seclytics/bloom_category.py
+++ b/seclytics/bloom_category.py
@@ -37,15 +37,18 @@ class BloomCategory(object):
         To reduce bloom filter checks we store ALL ips in has_intel
         This way the majority of IPs will only have to check once.
         """
+        ret = None
         if not self.check_has_intel(ip_addr):
-            return None
+            # No intel here, return None
+            return ret
+        # Determine what kind of intel we have
         if check_predicted and self.check_predicted(ip_addr):
-            return Category.predicted
-        if check_malicious and self.check_malicious(ip_addr):
-            return Category.malicious
-        if check_suspicious:
-            return Category.suspicious
-        return None
+            ret = Category.predicted
+        elif check_malicious and self.check_malicious(ip_addr):
+            ret = Category.malicious
+        elif check_suspicious:
+            ret = Category.suspicious
+        return ret
 
     def check_has_intel(self, ip_addr):
         """Check if IP is predicted."""

--- a/seclytics/scripts/download_db.py
+++ b/seclytics/scripts/download_db.py
@@ -37,6 +37,7 @@ def run():
     client = Seclytics(access_token=access_token, api_url=api_url)
     names = options.name.split(',')
     for name in names:
+        print(f'Downloading: {name} ...')
         client.bulk_api_download(name, data_dir=options.data_dir)
 
 

--- a/tests/test_bloom_category.py
+++ b/tests/test_bloom_category.py
@@ -59,13 +59,16 @@ class TestBloomCategory(object):
         # make sure all our IPs are in the bloom
         for ip_addr in malicious_ips:
             assert category.check_ip(ip_addr)
+            assert category.check_malicious(ip_addr)
         for ip_addr in all_ips:
             assert category.check_ip(ip_addr)
         for ip_addr in predicted_ips:
             assert category.check_ip(ip_addr)
+            assert category.check_predicted(ip_addr)
             ip_digit = None
             if sys.version_info < (3, 0):
                 ip_digit = str(int(ipaddress.IPv4Address(unicode(ip_addr))))
             else:
                 ip_digit = str(int(ipaddress.IPv4Address(ip_addr)))
             assert category.check_ip(ip_digit)
+            assert category.check_predicted(ip_digit)


### PR DESCRIPTION
If the client just want to check predicted ips, it shouldn't be
a requirement to download all 3 bloom filters.